### PR TITLE
Fix yaml loader warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 from ubuntu:bionic
 
-RUN apt-get update && apt-get install locales=git python3.6 python3-pip -qy && \
+RUN apt-get update && apt-get install locales git python3.6 python3-pip -qy && \
 pip3 install --upgrade pip setuptools && \
 if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
 if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \

--- a/hermes.py
+++ b/hermes.py
@@ -42,7 +42,7 @@ def watch_config(filename, url, command, interval, debug, yamlfile, secret_key_f
     try:
         if yamlfile:
             with open(yamlfile) as yamlhandle:
-                service_config = yaml.load(yamlhandle)
+                service_config = yaml.safe_load(yamlhandle)
                 # If no keys were passed, dont fail, just dont decrypt
                 # This is so hermes can function with no keys being passed.
                 for block in service_config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@
 #    make upgrade
 #
 asn1crypto==0.24.0        # via cryptography
-asym-crypto-yaml==0.0.5
+asym-crypto-yaml==0.0.6
 backoff==1.8.0
-boto3==1.9.134
-botocore==1.12.134        # via boto3, s3transfer
+boto3==1.9.148
+botocore==1.12.148        # via boto3, s3transfer
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
@@ -24,4 +24,4 @@ pyyaml==5.1               # via asym-crypto-yaml
 requests==2.21.0
 s3transfer==0.2.0         # via boto3
 six==1.12.0               # via cryptography, python-dateutil
-urllib3==1.24.2           # via botocore, requests
+urllib3==1.24.3           # via botocore, requests


### PR DESCRIPTION
Hermes has been throwing the following warning. This fixes it. I need to test this somehow.

```/edx/app/hermes/hermes/hermes.py:45: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.```