### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,17 @@ requirements:
 upgrade: ## update the pip requirements files to use the latest releases satisfying our constraints
 	docker-compose build && docker-compose run hermes make upgrade-requirements
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade-requirements: ## update the pip requirements files to use the latest releases satisfying our constraints
+upgrade-requirements: $(COMMON_CONSTRAINTS_TXT)
+	## update the pip requirements files to use the latest releases satisfying our constraints
 	pip install -q -r requirements/pip_tools.txt
+	pip-compile --allow-unsafe --upgrade -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip install -q -r requirements/pip.txt
+	pip install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,33 +6,33 @@
 #
 asym-crypto-yaml==0.1.2
     # via -r requirements/base.in
-backoff==1.11.1
+backoff==2.1.2
     # via -r requirements/base.in
-boto3==1.20.24
+boto3==1.24.16
     # via -r requirements/base.in
-botocore==1.23.24
+botocore==1.27.16
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
 cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.9
+charset-normalizer==2.0.12
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/base.in
     #   asym-crypto-yaml
-cryptography==36.0.0
+cryptography==37.0.2
     # via asym-crypto-yaml
 idna==3.3
     # via requests
-jmespath==0.10.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-newrelic==7.2.4.171
+newrelic==7.12.0.176
     # via -r requirements/base.in
 pycparser==2.21
     # via cffi
@@ -40,13 +40,13 @@ python-dateutil==2.8.2
     # via botocore
 pyyaml==6.0
     # via asym-crypto-yaml
-requests==2.26.0
+requests==2.28.0
     # via -r requirements/base.in
-s3transfer==0.5.0
+s3transfer==0.6.0
     # via boto3
 six==1.16.0
     # via python-dateutil
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   botocore
     #   requests

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,25 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<4.0
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,5 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+-c common_constraints.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,0 +1,6 @@
+-c constraints.txt
+# Core dependencies for installing other packages
+
+pip
+setuptools
+wheel

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,17 +4,13 @@
 #
 #    make upgrade
 #
-click==8.1.3
-    # via pip-tools
-pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
-    # via -r requirements/pip_tools.in
-tomli==2.0.1
-    # via pep517
 wheel==0.37.1
-    # via pip-tools
+    # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools
+pip==22.1.2
+    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions. For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.