### PR TITLE
fix: handle exception in copying config file and reloading supervisor

### DIFF
--- a/hermes.py
+++ b/hermes.py
@@ -98,7 +98,10 @@ def watch_config(filename, url, command, interval, jitter, debug, yamlfile, secr
 
 def run_command_for_filename(filename_item, command_item):
     logging.info('file \'%s\' changed, running: \'%s\'' % (filename_item, command_item))
-    logging.info(subprocess.check_output(command_item, shell=True).decode("utf-8"))
+    try:
+        logging.info(subprocess.check_output(command_item, shell=True).decode("utf-8"))
+    except subprocess.CalledProcessError as err:
+        logging.error(f"Command '{err.cmd}' returned non-zero exit status {err.returncode}: {err.output.decode('utf-8')}")
 
 def get_valid_protocol_from_url(url):
     if url.startswith("https://"):


### PR DESCRIPTION
Handling exceptions will be useful to trace errors if the command failed to copy the config file and reload the supervisor service to re-read the new config file. 

With current traceback, it is difficult to identify the issue
```
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]: Traceback (most recent call last):
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/edx/app/hermes/hermes/hermes.py", line 232, in <module>
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     watch_config()
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/edx/app/hermes/venvs/hermes/lib/python3.8/site-packages/click/core.py", line 11>
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     return self.main(*args, **kwargs)
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/edx/app/hermes/venvs/hermes/lib/python3.8/site-packages/click/core.py", line 10>
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     rv = self.invoke(ctx)
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/edx/app/hermes/venvs/hermes/lib/python3.8/site-packages/click/core.py", line 14>
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     return ctx.invoke(self.callback, **ctx.params)
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/edx/app/hermes/venvs/hermes/lib/python3.8/site-packages/click/core.py", line 76>
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     return __callback(*args, **kwargs)
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/edx/app/hermes/hermes/hermes.py", line 82, in watch_config
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     run_command_for_filename(filename_item, command_item)
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/edx/app/hermes/hermes/hermes.py", line 101, in run_command_for_filename
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     logging.info(subprocess.check_output(command_item, shell=True).decode("utf-8"))
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:   File "/usr/lib/python3.8/subprocess.py", line 516, in run
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]:     raise CalledProcessError(retcode, process.args,
Apr 10 10:19:55 ip-10-3-117-80 hermes.sh[788]: subprocess.CalledProcessError: Command 'sudo /bin/cp /edx/app/hermes/downloads/ecommerce
```